### PR TITLE
Removido DI da interface IBanco

### DIFF
--- a/BoletoAPI/BoletoAPI.Infrastructure.Data/Repositories/BoletoRepository.cs
+++ b/BoletoAPI/BoletoAPI.Infrastructure.Data/Repositories/BoletoRepository.cs
@@ -8,9 +8,8 @@ namespace BoletoAPI.Infrastructure.Data.Repositories
     {
         private IBanco _iBanco;
 
-        public BoletoRepository(IBanco iBanco)
+        public BoletoRepository()
         {
-            _iBanco = iBanco;
         }
 
         public string RetornarHTML(DadosBoleto dadosBoleto)


### PR DESCRIPTION
A classe Banco no BoletoNet é estática e também não é necessario passar por DI pois o banco esta sendo instanciado mais abaixo no código.